### PR TITLE
Fix 0-length buffer offset bug

### DIFF
--- a/src/data/statsd.js
+++ b/src/data/statsd.js
@@ -92,6 +92,10 @@ Statsd.prototype.flushBuffer = function() {
 }
 
 Statsd.prototype.flushToSocket = function() {
+  if(!this.buffer) {
+    return;
+  }
+
   var buffer = new Buffer(this.buffer.join('\n'));
 
   var response = (function(err, bytes) {


### PR DESCRIPTION
If the buffer was empty, statsd would attempt to send a 0-length buffer,
which would error:
https://github.com/joyent/node/blob/v0.10.28/lib/dgram.js#L254

:eyeglasses: @spladug 
