### PR TITLE
Fix inability to format `falsy` values

### DIFF
--- a/src/parameter.js
+++ b/src/parameter.js
@@ -86,10 +86,6 @@ Parameter.prototype.validate = function() {
 Parameter.prototype.format = function(req) {
   var config = this.config;
 
-  if (!this.val) {
-    return;
-  }
-
   if (config.truncate) {
     this.val = this.val.substring(0, config.truncate);
   }


### PR DESCRIPTION
I couldn't find a reason to not allow `undefined` and `null` to be formatted either, so that's why i wholesale removed it.
